### PR TITLE
fix: add empty class benefit option

### DIFF
--- a/src/pug/layout/character/classes.spine.pug
+++ b/src/pug/layout/character/classes.spine.pug
@@ -112,7 +112,7 @@
         label: 'Free Benefit',
         type: 'select',
         options: freeBenefitOptions,
-        value: 'hp',
+        value: 'none',
         css: { names: ['class__benefit'], modifiers: ['center'] },
       },
       {

--- a/src/ts/constants.ts
+++ b/src/ts/constants.ts
@@ -780,6 +780,7 @@ const CHARACTER_SKILL_LEVEL: SectionDetails[] = [
 ];
 
 const CLASS_BENEFIT: { [key: string]: number } = {
+  none: 0,
   hp: 5,
   mp: 5,
   ip: 2,


### PR DESCRIPTION
If the user missclick and add a class that is removed, the free benefit to hp, mp or ip stays and cannot be removed.

Add an empty option to the selector to avoid free benefit from ghost classes.