### PR TITLE
fix: properly display non-standard character in rolltemplate

### DIFF
--- a/src/ts/diceworkers.ts
+++ b/src/ts/diceworkers.ts
@@ -645,7 +645,7 @@ const customCheckTemplate = (action: string, values: { [key: string]: string }) 
     template.att1 = att1;
     template.att2 = att2;
     template.name = (getTranslationByKey(action) || COMMON_CHECKS[check].label)
-      .match(/^[\w\s]+/)
+      .match(/^[^【]+/)
       .shift();
     template.special = getTranslationByKey(`${action}_title`) || COMMON_CHECKS[check].title;
     template.accuracy = values[COMMON_CHECKS[check].accuracy];


### PR DESCRIPTION
Some of the roll names are not well displayed in case there is a non-word character in a translation, for example with some letters like É or ' character.

Translation regex has been updated in customCheckTemplate function.